### PR TITLE
Make it possible to create edge and connection separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ when they return a connection type that only supports forward pagination.
 when they return a connection type that only supports backward pagination.
  - `Relay::connectionDefinitions` returns a `connectionType` and its associated
 `edgeType`, given a node type.
+ - `Relay::edgeType` returns a new `edgeType`
+ - `Relay::connectionType` returns a new `connectionType`
  - `Relay::connectionFromArray` is a helper method that takes an array and the
 arguments from `connectionArgs`, does pagination and filtering, and returns
 an object in the shape expected by a `connectionType`'s `resolve` function.
@@ -73,7 +75,17 @@ An example usage of these methods from the [test schema](tests/StarWarsSchema.ph
 $shipConnection = Relay::connectionDefinitions([
     'nodeType' => $shipType
 ]);
-  
+
+// this could also be written as
+//
+// $shipEdge = Relay::edgeType([
+//     'nodeType' => $shipType
+// ]);
+// $shipConnection = Relay::connectionType([
+//     'nodeType' => $shipType,
+//     'edgeType' => $shipEdge
+// ]);
+
 $factionType = new ObjectType([
     'name' => 'Faction',
     'description' => 'A faction in the Star Wars saga',

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -72,14 +72,9 @@ class Connection {
      */
     public static function connectionDefinitions(array $config)
     {
-        $edgeType = array_key_exists('edgeType', $config) ? $config['edgeType'] : null;
-
-        $edgeType = $edgeType ? : self::createEdgeType($config);
-        $connectionType = self::createConnectionType(array_merge($config, ['edgeType' => $edgeType]));
-
         return [
-            'edgeType' => $edgeType,
-            'connectionType' => $connectionType
+            'edgeType' => self::createEdgeType($config),
+            'connectionType' => self::createConnectionType($config)
         ];
     }
 

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -72,13 +72,70 @@ class Connection {
      */
     public static function connectionDefinitions(array $config)
     {
+        $edgeType = array_key_exists('edgeType', $config) ? $config['edgeType'] : null;
+
+        $edgeType = $edgeType ? : self::createEdgeType($config);
+        $connectionType = self::createConnectionType(array_merge($config, ['edgeType' => $edgeType]));
+
+        return [
+            'edgeType' => $edgeType,
+            'connectionType' => $connectionType
+        ];
+    }
+
+    /**
+     * Returns a GraphQLObjectType for a connection with the given name,
+     * and whose nodes are of the specified type.
+     *
+     * @return ObjectType
+     */
+    public static function createConnectionType(array $config)
+    {
         if (!array_key_exists('nodeType', $config)){
             throw new \InvalidArgumentException('Connection config needs to have at least a node definition');
         }
         $nodeType = $config['nodeType'];
         $name = array_key_exists('name', $config) ? $config['name'] : $nodeType->name;
-        $edgeFields = array_key_exists('edgeFields', $config) ? $config['edgeFields'] : [];
         $connectionFields = array_key_exists('connectionFields', $config) ? $config['connectionFields'] : [];
+        $edgeType = array_key_exists('edgeType', $config) ? $config['edgeType'] : null;
+
+        $connectionType = new ObjectType([
+            'name' => $name . 'Connection',
+            'description' => 'A connection to a list of items.',
+            'fields' => function() use ($edgeType, $connectionFields, $config) {
+                return array_merge([
+                    'pageInfo' => [
+                        'type' => Type::nonNull(self::pageInfoType()),
+                        'description' => 'Information to aid in pagination.'
+                    ],
+                    'edges' => [
+                        'type' => function() use ($edgeType, $config) {
+                            return Type::listOf($edgeType ?: self::createEdgeType($config));
+                        },
+                        'description' => 'Information to aid in pagination'
+                    ]
+                ], self::resolveMaybeThunk($connectionFields));
+            }
+        ]);
+
+        return $connectionType;
+    }
+
+    /**
+     * Returns a GraphQLObjectType for an edge with the given name,
+     * and whose nodes are of the specified type.
+     *
+     * @param array $config
+     * @return ObjectType
+     */
+    public static function createEdgeType(array $config)
+    {
+        if (!array_key_exists('nodeType', $config)){
+            throw new \InvalidArgumentException('Edge config needs to have at least a node definition');
+        }
+        $nodeType = $config['nodeType'];
+        $name = array_key_exists('name', $config) ? $config['name'] : $nodeType->name;
+        $edgeFields = array_key_exists('edgeFields', $config) ? $config['edgeFields'] : [];
         $resolveNode = array_key_exists('resolveNode', $config) ? $config['resolveNode'] : null;
         $resolveCursor = array_key_exists('resolveCursor', $config) ? $config['resolveCursor'] : null;
 
@@ -101,27 +158,7 @@ class Connection {
             }
         ]));
 
-        $connectionType = new ObjectType([
-            'name' => $name . 'Connection',
-            'description' => 'A connection to a list of items.',
-            'fields' => function() use ($edgeType, $connectionFields) {
-                return array_merge([
-                    'pageInfo' => [
-                        'type' => Type::nonNull(self::pageInfoType()),
-                        'description' => 'Information to aid in pagination.'
-                    ],
-                    'edges' => [
-                        'type' => Type::listOf($edgeType),
-                        'description' => 'Information to aid in pagination'
-                    ]
-                ], self::resolveMaybeThunk($connectionFields));
-            }
-        ]);
-
-        return [
-            'edgeType' => $edgeType,
-            'connectionType' => $connectionType
-        ];
+        return $edgeType;
     }
 
     /**

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -8,6 +8,7 @@
 namespace GraphQLRelay;
 
 
+use GraphQL\Type\Definition\ObjectType;
 use GraphQLRelay\Connection\ArrayConnection;
 use GraphQLRelay\Connection\Connection;
 use GraphQLRelay\Mutation\Mutation;
@@ -48,7 +49,7 @@ class Relay {
     }
 
     /**
-     * Returns a GraphQLObjectType for a connection with the given name,
+     * Returns a GraphQLObjectType for a connection and its edge with the given name,
      * and whose nodes are of the specified type.
      *
      * @param array $config
@@ -57,6 +58,30 @@ class Relay {
     public static function connectionDefinitions(array $config)
     {
         return Connection::connectionDefinitions($config);
+    }
+
+    /**
+     * Returns a GraphQLObjectType for a connection with the given name,
+     * and whose nodes are of the specified type.
+     *
+     * @param array $config
+     * @return ObjectType
+     */
+    public static function connection(array $config)
+    {
+        return Connection::createConnectionType($config);
+    }
+
+    /**
+     * Returns a GraphQLObjectType for a edge with the given name,
+     * and whose nodes are of the specified type.
+     *
+     * @param array $config
+     * @return ObjectType
+     */
+    public static function edge(array $config)
+    {
+        return Connection::createEdgeType($config);
     }
 
     /**

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -67,7 +67,7 @@ class Relay {
      * @param array $config
      * @return ObjectType
      */
-    public static function connection(array $config)
+    public static function connectionType(array $config)
     {
         return Connection::createConnectionType($config);
     }
@@ -79,7 +79,7 @@ class Relay {
      * @param array $config
      * @return ObjectType
      */
-    public static function edge(array $config)
+    public static function edgeType(array $config)
     {
         return Connection::createEdgeType($config);
     }

--- a/tests/Connection/ArrayConnectionTest.php
+++ b/tests/Connection/ArrayConnectionTest.php
@@ -7,8 +7,6 @@
 
 namespace GraphQLRelay\Tests\Connection;
 
-
-use DoctrineTest\InstantiatorTestAsset\ArrayObjectAsset;
 use GraphQLRelay\Connection\ArrayConnection;
 
 class ArrayConnectionTest extends \PHPUnit_Framework_TestCase

--- a/tests/RelayTest.php
+++ b/tests/RelayTest.php
@@ -7,11 +7,8 @@
 
 namespace GraphQLRelay\tests;
 
-
-use GraphQLRelay\Connection\ArrayConnection;
+use GraphQL\Type\Definition\ObjectType;
 use GraphQLRelay\Connection\Connection;
-use GraphQLRelay\Mutation\Mutation;
-use GraphQLRelay\Node\Node;
 use GraphQLRelay\Relay;
 
 class RelayTest extends \PHPUnit_Framework_TestCase
@@ -37,6 +34,39 @@ class RelayTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             Connection::connectionArgs(),
             Relay::connectionArgs()
+        );
+    }
+
+    public function testConnectionDefinitions()
+    {
+        $nodeType = new ObjectType(['name' => 'test']);
+        $config = ['nodeType' => $nodeType];
+
+        $this->assertEquals(
+            Connection::connectionDefinitions($config),
+            Relay::connectionDefinitions($config)
+        );
+    }
+
+    public function testConnectionType()
+    {
+        $nodeType = new ObjectType(['name' => 'test']);
+        $config = ['nodeType' => $nodeType];
+
+        $this->assertEquals(
+            Connection::createConnectionType($config),
+            Relay::connectionType($config)
+        );
+    }
+
+    public function testEdgeType()
+    {
+        $nodeType = new ObjectType(['name' => 'test']);
+        $config = ['nodeType' => $nodeType];
+
+        $this->assertEquals(
+            Connection::createEdgeType($config),
+            Relay::edgeType($config)
         );
     }
 }


### PR DESCRIPTION
### UseCase

We use graphql-php but on top of that created the possibility to create types with annotations on our db-entities. In order to make this working in the best way possible every type has a factory (`ObjectTypeFactory`, `InterfaceTypeFactory`, `NonNullFactory`, ...). These factories and our `TypeRegistry` (which stores all created types) ensures we create every type only once, even if annotations are used multiple times.

We are now approaching relay and want to do the same with connection and edge (`ConnectionTypeFactory`, `EdgeTypeFactory`). In this scenario our implementation fails as we cannot get the edge type independently from the connection type. So when using `Relay::connectionDefinitions()` it always creates an edge type (without going through our registry) and uses it in the connection. If we later in the `returnType` of one of our mutations want to return an edge we would need to call `Relay::connectionDefinitions()` again to create the same edge again.

At this point grapql-php throws as we now created two types (e.g. `AccountEdge`) with the same name.

To circumvent this limitation what we want to achieve is creating the `Edge-ObjectType` alone (as we might also use it independent of connections in mutations), and being able to set the `edgeType` for the `Connection-ObjectType` somehow.

<hr />

There are a two solutions I found so far, that are not specific to our usecase described above, but meant to be more generic:
### 1. add edgeType to $config for Connection::connectionDefinitions()

This would allow to set the `edgeType` from the outside, so that we could create the EdgeType somewhere else, store it in the Registry, and when creating the Connection retrieving it from the Registry and supplying it to `Relay::connectionDefinitions()`

Disadvantage is that in order to create the EdgeType we would need to call `Relay::connectionDefinitions()` (and not using the created connection at all) and then later call it again to create the connection with the previously created edge. Seems to me stupid to create a connection when all we want is an edge.
### 2. separate Connection::connectionDefinitions() into two methods

By separating `connectionDefintions` into two methods, one for creating the edgeType and on for the connectionType we can create both types in completely independent Factories without having to create connection when we create the edge or the other way around. The method to create the connection obviously also needs to do what is described in 1.

This PR is implementing this solution, although there are some things I'm still unsure:
`Connection:: createEdgeType()` might be better suited in its own class `Edge:createEdgeType`? Then the name would be redundant so maybe `Edge::createType()` or `Edge::createDefinition()`?
I left the original `::connectionDefinitions` as it would stell be a valid shortcut to retrieve connection+edge at once. So this change right now is not breaking.
I also added `Relay::connection()` and `Relay::edge()`. Not sure about the naming, but I wanted to make sure it is not confusable with `Relay::connectionDefinitions()`.

Let me know what you think about it? I could also then update the Readme/docs/tests.
