### PR TITLE
Only create coverage for src folder

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,9 +5,8 @@
         </testsuite>
     </testsuites>
     <filter>
-        <blacklist>
-            <directory>./vendor</directory>
-            <directory>./bin</directory>
-        </blacklist>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
Currently the coverage also includes some files from the test folder
This changes phpunit to only include files from src by using a whitelist.

If it was intended, that the two test files are in the coverage report feel free to close.

The docs are here: https://phpunit.de/manual/current/en/code-coverage-analysis.html#code-coverage-analysis.whitelisting-files
