### PR TITLE
$typeResolver parameter of nodeDefinitions now optional

### DIFF
--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -104,9 +104,7 @@ class Connection {
                         'description' => 'Information to aid in pagination.'
                     ],
                     'edges' => [
-                        'type' => function() use ($edgeType, $config) {
-                            return Type::listOf($edgeType ?: self::createEdgeType($config));
-                        },
+                        'type' => Type::listOf($edgeType ?: self::createEdgeType($config)),
                         'description' => 'Information to aid in pagination'
                     ]
                 ], self::resolveMaybeThunk($connectionFields));

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -28,7 +28,7 @@ class Node {
      * @param callable $typeResolver
      * @return array
      */
-    public static function nodeDefinitions(callable $idFetcher, callable $typeResolver) {
+    public static function nodeDefinitions(callable $idFetcher, callable $typeResolver = null) {
         $nodeInterface = new InterfaceType([
             'name' => 'Node',
             'description' => 'An object with an ID',

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -176,7 +176,7 @@ class Relay {
      * @param callable $typeResolver
      * @return array
      */
-    public static function nodeDefinitions(callable $idFetcher, callable $typeResolver) {
+    public static function nodeDefinitions(callable $idFetcher, callable $typeResolver = null) {
         return Node::nodeDefinitions($idFetcher, $typeResolver);
     }
 


### PR DESCRIPTION
According to this snippet from the documentation, parameter `typeResolver` of `Relay::nodeDefinitions` is facultative.

> If the typeResolver is omitted, object resolution on the interface will be handled with the `isTypeOf` method on object types, as with any GraphQL interface without a provided `resolveType` method.
