### PR TITLE
Includes `totalCount` and `nodes` in connection

### DIFF
--- a/src/Connection/ArrayConnection.php
+++ b/src/Connection/ArrayConnection.php
@@ -131,6 +131,8 @@ class ArrayConnection
 
         return [
             'edges' => $edges,
+            'totalCount' => $arrayLength,
+            'nodes' => $slice,
             'pageInfo' => [
                 'startCursor' => $firstEdge ? $firstEdge['cursor'] : null,
                 'endCursor' => $lastEdge ? $lastEdge['cursor'] : null,

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -103,9 +103,17 @@ class Connection {
                         'type' => Type::nonNull(self::pageInfoType()),
                         'description' => 'Information to aid in pagination.'
                     ],
+                    'totalCount' => [
+                        'type' => Type::Int(),
+                        'description' => sprintf('The count of all %s you could get from the connection.', $config['nodeType'])
+                    ],
+                    'nodes' => [
+                        'type' => Type::listOf($config['nodeType']),
+                        'description' => sprintf('A list of %s objects.', $config['nodeType'])
+                    ],
                     'edges' => [
                         'type' => Type::listOf($edgeType ?: self::createEdgeType($config)),
-                        'description' => 'Information to aid in pagination'
+                        'description' => sprintf('A list of edges which contains the %s and cursor to aid in pagination.', $config['nodeType'])
                     ]
                 ], self::resolveMaybeThunk($connectionFields));
             }


### PR DESCRIPTION
I've been using [postgraphQL](https://github.com/postgraphql/postgraphql) which includes `totalCount` and `nodes` in the connection information. 
`totalCount` can be quite useful for the UI.