### PR TITLE
Adds description and deprecationReason in mutationWithClientMutationId

### DIFF
--- a/src/Mutation/Mutation.php
+++ b/src/Mutation/Mutation.php
@@ -33,6 +33,8 @@ class Mutation {
      *
      * type MutationConfig = {
      *   name: string,
+     *   description?: string,
+     *   deprecationReason?: string,
      *   inputFields: InputObjectConfigFieldMap,
      *   outputFields: GraphQLFieldConfigMap,
      *   mutateAndGetPayload: mutationFn,
@@ -73,7 +75,7 @@ class Mutation {
             'fields' => $augmentedInputFields
         ]);
 
-        return [
+        $definition = [
             'type' => $outputType,
             'args' => [
                 'input' => [
@@ -86,6 +88,13 @@ class Mutation {
                 return $payload;
             }
         ];
+	    if (array_key_exists('description', $config)){
+		    $definition['description'] = $config['description'];
+	    }
+	    if (array_key_exists('deprecationReason', $config)){
+		    $definition['deprecationReason'] = $config['deprecationReason'];
+	    }
+        return $definition;
     }
 
     /**


### PR DESCRIPTION
Changes in the JS implementation:
- description: https://github.com/graphql/graphql-relay-js/commit/7312c84d878ad80c056fcf5ef19665136ae064c4
- deprecationReason: https://github.com/graphql/graphql-relay-js/commit/34d5fc5a256c9b8a199eaef051788767876d4820